### PR TITLE
Add URL for hashlk_0.2.0.0.zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ In order to add your chain to the registry, please do as follows:
 
 ## Examples
 You can find examples of chains definition inside the `/chains` folder.
+
+## hashlnk_0.2.0.0.zip
+The file `hashlnk_0.2.0.0.zip` can be found at the following URL:
+[https://github.com/riverar/hashlnk/blob/master/bin/hashlnk_0.2.0.0.zip](https://github.com/riverar/hashlnk/blob/master/bin/hashlnk_0.2.0.0.zip)


### PR DESCRIPTION
Fixes #76

Add a new section to the `README.md` file to include the URL for `hashlnk_0.2.0.0.zip`.

* Add a new section titled "hashlnk_0.2.0.0.zip" to the `README.md` file.
* Provide a brief description of the file `hashlnk_0.2.0.0.zip`.
* Include the URL [https://github.com/riverar/hashlnk/blob/master/bin/hashlnk_0.2.0.0.zip](https://github.com/riverar/hashlnk/blob/master/bin/hashlnk_0.2.0.0.zip) in the new section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/UCRegistry/chain-registry/pull/92?shareId=3362e7f5-deb0-484b-9117-4b93c326b7f5).